### PR TITLE
Allow plotting clusters with a single member

### DIFF
--- a/R/mfuzz.plot.R
+++ b/R/mfuzz.plot.R
@@ -22,7 +22,7 @@ colorseq <- seq(0,1,length=length(colo))
 
 
 for (j in 1:max(clusterindex)){
-  tmp <- exprs(eset)[clusterindex==j,]
+  tmp <- exprs(eset)[clusterindex==j, , drop=FALSE]
   tmpmem <- memship[clusterindex==j,j]
 
   if (((j-1)%% (mfrow[1] * mfrow[2]))==0){

--- a/R/mfuzz.plot2.R
+++ b/R/mfuzz.plot2.R
@@ -39,7 +39,7 @@ colorseq <- seq(0,1,length=length(colo))
 
 for (j in 1:dim(cl[[1]])[[1]]){
   if (single) j <- single
-  tmp <- exprs(eset)[clusterindex==j,]
+  tmp <- exprs(eset)[clusterindex==j, , drop=FALSE]
   tmpmem <- memship[clusterindex==j,j]
   if (((j-1)%% (mfrow[1] * mfrow[2]))==0 | single){
   if (x11) X11(width=Xwidth,height=Xheight)


### PR DESCRIPTION
This is a really trivial patch, but a colleague just came across an edge case where he had a cluster with a single member and mfuzz.plot and mfuzz.plot2 can't handle that.